### PR TITLE
Run EF Core migrations automatically on startup

### DIFF
--- a/Goalkeeper.Server/Program.cs
+++ b/Goalkeeper.Server/Program.cs
@@ -19,6 +19,12 @@ builder.Services.AddControllers();
 
 var app = builder.Build();
 
+await using (var scope = app.Services.CreateAsyncScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<GoalkeeperDbContext>();
+    await db.Database.MigrateAsync();
+}
+
 // Configure the HTTP request pipeline.
 app.UseExceptionHandler();
 


### PR DESCRIPTION
Creates an async scope after app.Build() and calls MigrateAsync() so that any pending database migrations are applied before the server starts accepting requests.

https://claude.ai/code/session_01NeCQSPph24uSibFDYEX8Da