### PR TITLE
Seed 48 tournament teams into the Teams table on startup

### DIFF
--- a/Goalkeeper.Server/Infrastructure/Data/DbSeeder.cs
+++ b/Goalkeeper.Server/Infrastructure/Data/DbSeeder.cs
@@ -1,0 +1,44 @@
+using Goalkeeper.Server.Core;
+using Microsoft.EntityFrameworkCore;
+
+namespace Goalkeeper.Server.Infrastructure.Data;
+
+public static class DbSeeder
+{
+    private static readonly string[] TeamNames =
+    [
+        // Group A
+        "Mexico", "South Africa", "South Korea", "Czech Republic",
+        // Group B
+        "Canada", "Bosnia & Herzegovina", "Qatar", "Switzerland",
+        // Group C
+        "Brazil", "Morocco", "Haiti", "Scotland",
+        // Group D
+        "USA", "Paraguay", "Australia", "Turkey",
+        // Group E
+        "Germany", "Curaçao", "Ivory Coast", "Ecuador",
+        // Group F
+        "Netherlands", "Japan", "Sweden", "Tunisia",
+        // Group G
+        "Belgium", "Egypt", "Iran", "New Zealand",
+        // Group H
+        "Spain", "Cape Verde", "Saudi Arabia", "Uruguay",
+        // Group I
+        "France", "Senegal", "Iraq", "Norway",
+        // Group J
+        "Argentina", "Algeria", "Austria", "Jordan",
+        // Group K
+        "Portugal", "DR Congo", "Uzbekistan", "Colombia",
+        // Group L
+        "England", "Croatia", "Ghana", "Panama",
+    ];
+
+    public static async Task SeedTeamsAsync(GoalkeeperDbContext context)
+    {
+        if (await context.Teams.AnyAsync())
+            return;
+
+        context.Teams.AddRange(TeamNames.Select(name => new Team { Name = name }));
+        await context.SaveChangesAsync();
+    }
+}

--- a/Goalkeeper.Server/Program.cs
+++ b/Goalkeeper.Server/Program.cs
@@ -23,6 +23,7 @@ await using (var scope = app.Services.CreateAsyncScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<GoalkeeperDbContext>();
     await db.Database.MigrateAsync();
+    await DbSeeder.SeedTeamsAsync(db);
 }
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
Adds DbSeeder.SeedTeamsAsync() which inserts all 48 teams (groups A–L) when the Teams table is empty. Called once after EF Core migrations run, making repeated restarts idempotent.

https://claude.ai/code/session_01NeCQSPph24uSibFDYEX8Da