### PR TITLE
Add useTeams hook and teams API client to React frontend

### DIFF
--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -1,0 +1,14 @@
+export interface Team {
+  id: number
+  name: string
+}
+
+export async function fetchTeams(): Promise<Team[]> {
+  const response = await fetch('/api/teams')
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch teams: ${response.status} ${response.statusText}`)
+  }
+
+  return response.json() as Promise<Team[]>
+}

--- a/frontend/src/hooks/useTeams.ts
+++ b/frontend/src/hooks/useTeams.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react'
+import { fetchTeams, type Team } from '../api/teams'
+
+interface UseTeamsResult {
+  teams: Team[]
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useTeams(): UseTeamsResult {
+  const [teams, setTeams] = useState<Team[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const data = await fetchTeams()
+      setTeams(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch teams')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return { teams, loading, error, refetch: load }
+}


### PR DESCRIPTION
Adds two files:
- src/api/teams.ts: Team interface and fetchTeams() function that calls GET /api/teams
- src/hooks/useTeams.ts: useTeams() hook exposing { teams, loading, error, refetch }

https://claude.ai/code/session_01NeCQSPph24uSibFDYEX8Da