### PR TITLE
Add devcontainer support for frontend and Goalkeeper.Server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+  "name": "Goalkeeper",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+  },
+  "forwardPorts": [5445, 5173, 15888, 18888],
+  "portsAttributes": {
+    "5445": {
+      "label": "Goalkeeper Server",
+      "onAutoForward": "notify"
+    },
+    "5173": {
+      "label": "Frontend Dev Server",
+      "onAutoForward": "notify"
+    },
+    "15888": {
+      "label": "Aspire Dashboard",
+      "onAutoForward": "openBrowser"
+    },
+    "18888": {
+      "label": "Aspire OTLP",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "dotnet restore Goalkeeper.slnx && cd frontend && npm install",
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` with a .NET 10 + Node.js LTS + Docker-in-Docker setup
- The existing `dotnet run --project Goalkeeper.AppHost` command works as-is inside the devcontainer — Aspire orchestrates SQL Server (via Docker), the ASP.NET Core server, and the Vite frontend exactly as in local dev
- `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true` is set so the Aspire dashboard is reachable over HTTP without certificate issues in the container
- Forwards ports for the server (5445), Vite dev server (5173), and Aspire dashboard (15888 / 18888)
- `postCreateCommand` restores NuGet packages and installs frontend npm dependencies automatically on container creation

## VS Code extensions pre-installed

- C# + C# Dev Kit (IntelliSense, debugging)
- .NET Install Tool
- ESLint
- Tailwind CSS IntelliSense
- Docker

## Test plan

- [ ] Open repo in a devcontainer (VS Code "Reopen in Container" or GitHub Codespaces)
- [ ] Confirm `dotnet run --project Goalkeeper.AppHost` starts without errors
- [ ] Confirm Aspire dashboard URL appears in terminal output and port is forwarded
- [ ] Confirm server health check responds at `http://localhost:5445/health`
- [ ] Confirm Vite dev server is reachable at `http://localhost:5173`

https://claude.ai/code/session_01C6te6dKiMa5BUJHcYYiEg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6te6dKiMa5BUJHcYYiEg7)_